### PR TITLE
Add GCC>=10 specific option -fallow-argument-mismatch to CMake build infrastructure

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,13 @@ add_definitions("-DSCHISM")
 ########### Announce compiler #####
 message(STATUS "\n### Your compiler is ${CMAKE_Fortran_COMPILER}")
 
-
+# @todo this is a tempoary fix for gcc10 and greater until this is 
+# resolved in later versions of gcc
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+  if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "10.0.0" )
+    add_compile_options(-fallow-argument-mismatch)
+  endif()
+endif()
 
 ########### Build types are Release, Debug and RelWithDebInfo (Release with debug info) #####
 if (NOT CMAKE_BUILD_TYPE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,10 +34,11 @@ add_definitions("-DSCHISM")
 message(STATUS "\n### Your compiler is ${CMAKE_Fortran_COMPILER}")
 
 # @todo this is a tempoary fix for gcc10 and greater until this is 
-# resolved in later versions of gcc
+# resolved in later versions of gcc; currently, we apply this to 
+# C and Fortran, resulting in a warning when compiling the C parts
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
   if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "10.0.0" )
-    add_compile_options(-fallow-argument-mismatch)
+      add_compile_options(-fallow-argument-mismatch)
   endif()
 endif()
 


### PR DESCRIPTION
This PR adds GCC>=10 specific option -fallow-argument-mismatch to CMake build infrastructure by adding 
this option if the GNU compiler >=10.0.0 is detected.

This is confirmed working with intel and gcc and should be merged despite two remaining issues:

1.  Only implemented for CMake build infrastructure, not the regular make
2. Currently the flag is applied to the C build (Metis) as well and issues lots of warnings.