### PR TITLE
Pacific model 2021 adding regional refinements to basin scale mesh

### DIFF
--- a/src/Utility/Pre-Processing/Pacific_project_2021/regional_mesh_refinement/README
+++ b/src/Utility/Pre-Processing/Pacific_project_2021/regional_mesh_refinement/README
@@ -1,0 +1,1 @@
+This folder contains regional mesh refinements for specific priority islands and locations within the Pacific Basin. Basin scale meshes are named in reference to the basin scale mesh to which regional refinements were added (e.g. new16_TLFiji.map adds Timor Leste and Fiji to the new16.map in the main Pacific_project_2021 folder)


### PR DESCRIPTION
Created a folder for regional refinements to the basin scale meshes, and added an initial basin scale mesh based on new16, incorporating refinements for Timor Leste, Fiji, and the Columbia River.