### PR TITLE
add sample ubuntu config file

### DIFF
--- a/cmake/SCHISM.local.ubuntu
+++ b/cmake/SCHISM.local.ubuntu
@@ -1,0 +1,6 @@
+# what follows is a simple configuration that was observed to work on Ubuntu 20.04 on  2021-10-13
+
+set(CMAKE_Fortran_COMPILER gfortran CACHE PATH "Path to serial Fortran compiler")
+set(CMAKE_C_COMPILER gcc CACHE PATH "Path to serial C compiler")
+set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -ffree-line-length-none -static-libgfortran -finit-local-zero" CACHE STRING "Fortran flags" FORCE)
+


### PR DESCRIPTION
Per the discussion in issue #46 , I've added a SCHISM.local.ubuntu file to the cmake directory.

Perhaps more important is this informal install script for ubuntu, including a list of packages and the use of update-alternatives. I'm not sure where this belongs, so I'm going to include it here.

```

What follows is what appears to me to be a complete set of steps, but
I haven't run these on a totally fresh install of Ubuntu, so it's concievable
that I've missed one or more packages that are required. Edits welcome!


* Start with fresh Ubuntu 20.04.

* First, install a bunch of packages:

> sudo apt install gcc g++ gfortran netcdf openmpi-bin libnetcdf-dev libopenmpi-dev openmpi-bin python2

* Next, the world has moved on and python 2 is no longer standard; the "update-alternatives"
  utility can create a link that causes python to invoke python v2.7:

> sudo update-alternatives --install /usr/local/bin/python python /usr/bin/python2 20

* Now, check out the schism repo:

> cd ~
> git clone https://github.com/schism-dev/schism.git
> cd schism/
> git checkout tags/v5.9.0
> cd cmake

* create a file in the cmake directory called SCHISM.build.ubuntu, containing this text:

* * *
set(CMAKE_Fortran_COMPILER gfortran CACHE PATH "Path to serial Fortran compiler")
set(CMAKE_C_COMPILER gcc CACHE PATH "Path to serial C compiler")
set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -ffree-line-length-none -static-libgfortran -finit-local-zero" CACHE STRING "Fortran flags" FORCE)
* * *

(Don't put the asterisks in there, those are just there to demarcate the
beginning and end of the file.)

(NB if my pull request is accepted upstream, this file may become
built-in.)

* Finally, run cmake and make:

> cd ~/schism/
> mkdir build
> cd build
> cmake -C ../cmake/SCHISM.local.build -C ../cmake/SCHISM.local.ubuntu ../src/
> make pschism

After this, the binary (just called pschism, I believe) should appear in
the bin/ subdirectory, and the libraries in ... another subdirectory,
mumble, let me know if you can't find them.
``` 