### PR TITLE
Docker image creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2022 Helmholtz-Zentrum Hereon
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileContributor Carsten Lemmen <carsten.lemmen@hereon.de
+
+FROM phusion/baseimage:jammy-1.0.1
+
+LABEL description="SCHISM Docker environment based on Ubuntu"
+LABEL author="Carsten Lemmen <carsten.lemmen@hereon.de>"
+LABEL license="CC0-1.0"
+LABEL copyright="2022 Helmholtz-Zentrum Hereon"
+
+# Arguments can be passed via the --build-arg key=value command to the 
+# docker build command.  The default values are set below to mpich, oldio=on,
+# and superbee 
+ARG COMMUNICATOR="mpich"
+ARG OLDIO="ON"
+ARG TVD_LIM="SB"
+
+RUN apt update && apt -qy install cmake gcc-11 python3 \
+    python-is-python3 lib${COMMUNICATOR}-dev libmetis-dev libnetcdf-dev \
+    libnetcdff-dev libparmetis-dev git
+ENV PATH="/usr/lib64/${COMMUNICATOR}/bin:${PATH}"
+
+WORKDIR /usr/src
+
+RUN git clone  --branch master --depth 1 https://github.com/schism-dev/schism /usr/src/schism
+RUN mkdir -p /usr/src/schism/build
+RUN cmake -S /usr/src/schism/src -B /usr/src/schism/build -DOLDIO=${OLDIO} -DTVD_LIM=${TVD_LIM}
+RUN make -C /usr/src/schism/build -j8 pschism

--- a/docs/coupling/nuopc.md
+++ b/docs/coupling/nuopc.md
@@ -4,7 +4,7 @@ SCHISM can be such a model component within an NUOPC-coupled system.  A so-calle
 
 ## Obtaining and building the cap
 
-The [NUOPC](nuopc.html)(esmf.html) cap are jointly hosted in a separate repository on [https://github.com/schism-dev/schism-esmf](https://github.com/schism-dev/schism-esmf).  It requires that the SCHISM core is built and pointed to by the environment variable `$SCHISM_BUILD_DIR` 
+The [NUOPC](nuopc.html) and the [ESMF](esmf.html) caps are jointly hosted in a separate repository on [https://github.com/schism-dev/schism-esmf](https://github.com/schism-dev/schism-esmf).  It requires that the SCHISM core is built and pointed to by the environment variable `$SCHISM_BUILD_DIR` 
 
 ```
 export SCHISM_ESMF_DIR=/my/path/to/schism-esmf


### PR DESCRIPTION
This new file allows to create a development image for SCHISM in a Docker container.  

To try, run 

```
docker build -t test . --build-arg COMMUNICATOR=mpich
```

Other optional arguments currently supported are `TVD_LIM` and `OLDIO`

At a later stage, the docker image should  be created in Continuous Deployment via a GitHub workflow.

