### PR TITLE
Add ptrack4 to src/Utility/Particle_Tracking/CMakeLists.txt

### DIFF
--- a/src/Utility/Particle_Tracking/CMakeLists.txt
+++ b/src/Utility/Particle_Tracking/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_executable(ptrack3 ptrack3.f90)
+add_executable(ptrack4 ptrack4.f90)
 
-add_dependencies(utility ptrack3)
+add_dependencies(utility ptrack3 ptrack4)
 target_link_libraries(ptrack3 utillib ${NetCDFLIBS} ${HDF5_LIBRARIES})
+target_link_libraries(ptrack4 utillib ${NetCDFLIBS} ${HDF5_LIBRARIES})
 
 


### PR DESCRIPTION
This enables cmake compilation of ptrack4 from src/Utility/Particle_Tracking/ptrack4.f90

You can test it on the schism_verification_tests/Test_QuarterAnnulus if you enable the velocities in param.nml:

```
  ...
  iof_hydro(17) = 1 !vertical velocity [m/s]
  iof_hydro(18) = 0 !water temperature [C]
  iof_hydro(19) = 0 !water salinity [PSU]
  iof_hydro(20) = 0 !water density [kg/m^3]
  iof_hydro(21) = 0 !eddy diffusivity [m^2/s]
  iof_hydro(22) = 0 !eddy viscosity [m^2/s]
  iof_hydro(23) = 0 !turbulent kinetic energy
  iof_hydro(24) = 0 !turbulent mixing length [m]
  iof_hydro(26) = 1 !horizontal vel vector [m/s]
  ...
```

... with a particle.bp file like this:

```
!input for ptrack4, 1 pts 
1 !nscreen
0 !mod_part
1 !ibf
0 !istiff
1 -75.460 37.125 !ics cpp_lon cpp_lat
0.01 5.0 300 3 480 10 !h0,rnday,dtm,nspool,ihfskip,ndeltp
1 !npt
  1   0.0   65000 4000 00.00 
```


