### PR TITLE
Get version from git under source tree, regardless of build path

### DIFF
--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -6,6 +6,7 @@ set(versionfile "${CMAKE_CURRENT_BINARY_DIR}/schism_version.F90")
 add_custom_target(
     sversion
     COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.py ${versionfile}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 set_source_files_properties(${versionfile} PROPERTIES GENERATED TRUE)


### PR DESCRIPTION
If a CMake build was configured in a path that wasn't a descendant of the source tree, `gen_version.py` would fail, because Git wouldn't be able to find its metadata. It should always run in the source tree, whether that build path is below that or not.