### PR TITLE
Update Utiilty/Preprocessing CMakeLists.txt

### DIFF
--- a/src/Utility/Pre-Processing/CMakeLists.txt
+++ b/src/Utility/Pre-Processing/CMakeLists.txt
@@ -14,7 +14,6 @@ add_executable( gen_slope_filter gen_slope_filter.f90 )
 add_executable( gen_slope_filter2 gen_slope_filter2.f90 )
 add_executable( gen_source gen_source.f90 )
 add_executable( gen_vqs_1 gen_vqs_1.f90 )
-add_executable( gen_vqs_2 gen_vqs_2.f90 )
 add_executable( gen_vqs_2masters gen_vqs_2masters.f90 )
 add_executable( list_bnd_pt list_bnd_pt.f90)
 add_executable( manning manning.f90)
@@ -39,7 +38,6 @@ set(utility_list
     gen_slope_filter2.f90
     gen_source.f90
     gen_vqs_1.f90
-    gen_vqs_2.f90
     gen_vqs_2masters.f90
     list_bnd_pt.f90
     manning.f90
@@ -47,13 +45,12 @@ set(utility_list
     viz_source.f90
     viz_source_sink.f90)
 
-add_dependencies(utility check_openbnd convert_3Dth_nc convert_nudge_nc fix_bad_quads find_small_elem gen_hdif gen_vqs_1 gen_vqs_2 gen_vqs_2masters gen_nudge gen_nudge2 gen_nudge_from_hycom gen_slope_filter gen_slope_filter2 gen_source list_bnd_pt manning split_quads_wwm viz_source )
+add_dependencies(utility check_openbnd convert_3Dth_nc convert_nudge_nc fix_bad_quads find_small_elem gen_hdif gen_vqs_1 gen_vqs_2masters gen_nudge gen_nudge2 gen_nudge_from_hycom gen_slope_filter gen_slope_filter2 gen_source list_bnd_pt manning split_quads_wwm viz_source )
 
 # add extra libraries for linking
 target_link_libraries(convert_3Dth_nc utillib ${NetCDFLIBS} ${HDF5_LIBRARIES})
 target_link_libraries(convert_nudge_nc utillib ${NetCDFLIBS} ${HDF5_LIBRARIES})
 target_link_libraries(gen_vqs_1 utillib)
-target_link_libraries(gen_vqs_2 utillib)
 target_link_libraries(gen_vqs_2masters utillib)
 target_link_libraries(gen_nudge_from_hycom utillib ${NetCDFLIBS} ${HDF5_LIBRARIES})
 


### PR DESCRIPTION
Removal of gen_vq_2.f90 causing SCHISM compilation failure for Utility repository. Removal in CMakeLists.txt is required unless this was by accident?