### PR TITLE
remove static definition of Python to process file

### DIFF
--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -3,9 +3,14 @@
 
 set(versionfile "${CMAKE_CURRENT_BINARY_DIR}/schism_version.F90")
 
+if (NOT Python_FOUND)
+  find_package(Python COMPONENTS Interpreter)
+  message(INFO " Python_EXECUTABLE = ${Python_EXECUTABLE}")
+endif()
+
 add_custom_target(
     sversion
-    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.py ${versionfile}
+    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.py ${versionfile}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 


### PR DESCRIPTION
The build is failing with following error in some cases (such as modifying UFS Coastal module file and point external ESMF library)

```
cd /work2/noaa/nems/tufuk/COASTAL/ufs-weather-model_fix/SCHISM-interface/SCHISM/src/Core && python /work2/noaa/nems/tufuk/COASTAL/ufs-weather-model_fix/SCHISM-interface/SCHISM/src/Core/gen_version.py /work2/noaa/nems/tufuk/COASTAL/ufs-weather-model_fix/tests/build_fv3_coastal/SCHISM-interface/SCHISM/src/Core/schism_version.F90
/bin/sh: line 1: python: command not found
```

Static definition of python interpreter like `python` is not working in all the cases. So, this fix basically allow Cmake to find out existing Python interpreter and use it to generate `schism_version.F90` file.