### PR TITLE
Update CMake bits to build successfully on CMake 4.0.0

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,6 @@
 
 ############# CMake versioning and backward compatibility #####
 cmake_minimum_required (VERSION 3.12)
-if(POLICY CMP0017)
-  cmake_policy(SET CMP0017 OLD)
-endif(POLICY CMP0017)
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 

--- a/src/ParMetis-4.0.3/CMakeLists.txt
+++ b/src/ParMetis-4.0.3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8...3.5)
 project(ParMETIS C CXX)
 
 ##set(GKLIB_PATH METIS/GKlib CACHE PATH "path to GKlib")

--- a/src/ParMetis-4.0.3/CMakeLists.txt
+++ b/src/ParMetis-4.0.3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8...3.5)
+cmake_minimum_required(VERSION 2.8...3.10)
 project(ParMETIS C CXX)
 
 ##set(GKLIB_PATH METIS/GKlib CACHE PATH "path to GKlib")


### PR DESCRIPTION
When attempting to configure and build SCHISM with the recently-released CMake 4.0.0, I encountered the following errors:

```
CMake Error at CMakeLists.txt:5 (cmake_policy):
  Policy CMP0017 may not be set to OLD behavior because this version of CMake
  no longer supports it.  The policy was introduced in CMake version 2.8.4,
  and use of NEW behavior is now required.

  Please either update your CMakeLists.txt files to conform to the new
  behavior or use an older version of CMake that still supports the old
  behavior.  Run cmake --help-policy CMP0017 for more information.
```

```
CMake Error at ParMetis-4.0.3/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

This PR addresses both of them, with no apparent ill effects.