### PR TITLE
Fixes #111 and other mixed clang/gfortran issues

### DIFF
--- a/cmake/SCHISM.local.conda
+++ b/cmake/SCHISM.local.conda
@@ -5,21 +5,7 @@
 # SPDX-License-Identifier: CC0-1.0
 # SPDX-FileContributor Carsten Lemmen <carsten.lemmen@hereon.de
 
-message(WARNING "If you get an error 'Error copying Fortran module' with uppercase/lowercase mismatch, then try setting the CMAKE_C_PREPROCESS_FLAG to an empty string in cmake/SCHISMCompile.cmake")
-
 set(CMAKE_Fortran_COMPILER $ENV{CONDA_PREFIX}/bin/mpifort CACHE PATH "Path to parallel Fortran compiler")
 set(CMAKE_C_COMPILER $ENV{CONDA_PREFIX}/bin/mpicc CACHE PATH "Path to parallel C compiler")
 set(CMAKE_CXX_COMPILER $ENV{CONDA_PREFIX}/bin/mpicxx CACHE PATH "Path to parallel C++ compiler")
 set(PARMETIS_ROOT $ENV{CONDA_PREFIX} CACHE PATH "Root path for external (par)metis")
-
-set_source_files_properties(
-  *.F90
-  PROPERTIES Fortran_PREPROCESS ON
-)
-
-# Fix gfortran/clang for conda environments
-if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
-    if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
-      set( C_PREPROCESS_FLAG "" CACHE STRING "C Preprocessor Flag")
-    endif()
-endif()

--- a/cmake/SCHISMCompile.cmake
+++ b/cmake/SCHISMCompile.cmake
@@ -38,10 +38,15 @@ if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
     set( CMAKE_Fortran_FLAGS_DEBUG_INIT "-g ${SCHISM_GFORTRAN_OPTIONS}")
     set( CMAKE_Fortran_FLAGS_RELWITHDEBINFO_INIT "-O2 -g ${SCHISM_GFORTRAN_OPTIONS}")
     unset( C_PREPROCESS_FLAG CACHE)
-    if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
-      set( C_PREPROCESS_FLAG "--preprocess" CACHE STRING "C Preprocessor Flag")
-    elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
-      set( C_PREPROCESS_FLAG "--preprocess" CACHE STRING "C Preprocessor Flag")
+    if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+      # gfortran cannot handle Clang's --preprocess flag, thus we need to 
+      # remove it (Clang preprocesses by default, even without the flag)
+      # and enable Fortran preprocessing for .f90 and F90 files.
+      set( C_PREPROCESS_FLAG "" CACHE STRING "C Preprocessor Flag")
+      set_source_files_properties(
+        *.F90 *.f90
+        PROPERTIES Fortran_PREPROCESS ON 
+      )
     else()
       set( C_PREPROCESS_FLAG "-cpp" CACHE STRING "C Preprocessor Flag")
     endif()


### PR DESCRIPTION
gfortran cannot handle Clang's --preprocess flag, thus we need to 
remove it (Clang preprocesses by default, even without the flag)
and enable Fortran preprocessing for .f90 and F90 files.
  
This fixes #111    