### PR TITLE
uneven timesteps for elev.th and flux.th

### DIFF
--- a/cmake/SCHISM.local.phil.bfg
+++ b/cmake/SCHISM.local.phil.bfg
@@ -1,0 +1,75 @@
+###W&M Whirlwind cluster
+#  Set the base name of the executable.
+#  The main reason for this is to include something like a cluster/architecture name.
+#  Do not add the file extension (none for linux, .exe for Windows etc)
+#  or the list of enabled modules, both of which will be automatically appended.
+set (SCHISM_EXE_BASENAME pschism_bfg CACHE STRING "Base name (modules and file extension to be added of the executable. If you want a machine name, add it here")
+
+
+
+##########################  LOCATIONS #########################################################
+#
+# LOCATIONS: Set locations for NetCDF (possibly HDF5 if NetCDF links to it), ParMetis, PETSc
+#            You don't need to set these if they are in your environment
+#
+#            Only the library home location is needed and the /lib or /bin part will be inferred.
+#            Generally traditional structure is assumed, but the Parmetis and GOTM libraries
+#            that are included have a slightly different structure
+#
+#            You only need GOTM if you intend to use it with USE_GOTM
+#            GOTM and ParMetis local copies will be found automatically, but also can overridden
+#            You have to build them
+#
+
+###Relative paths won't work
+set(CMAKE_Fortran_COMPILER mpif90 CACHE PATH "Path to serial Fortran compiler")
+set(NetCDF_FORTRAN_DIR "$ENV{NETCDF_FORTRAN}" CACHE PATH "Path to NetCDF Fortran library")
+set(NetCDF_C_DIR  "$ENV{NETCDF}"  CACHE PATH "Path to NetCDF C library")
+###MPI_ROOT is only needed when cmake is having trouble finding write MPI wrapper
+#set(MPI_ROOT /opt/mvapich2/2.3-intel CACHE PATH "Root dir of MPI implementation")
+
+#set(HDF5_DIR  /opt/hdf5/1.10.4-intel64 CACHE PATH "Path to HDF5")
+#set(SZIP_DIR /opt/szip/2.1.1-intel64 CACHE PATH "Path to SZip compression library")
+
+
+######################## COMPILE AND BUILD OPTIONS ##############################################
+#
+# BUILD OPTS: Use this to set compiler flags any way you want.For models of how to set flags, 
+#             see SCHISMCompile.cmake, which are the project defaults.
+#
+#             If you are setting up a new platform/compiler combo rather than customizing, 
+#             you might consider adding to SCHISMCompile.cmake with the correct "IF" so 
+#             others can profit from your work.
+#             
+#             If what you are doing is debugging, consider using -DBUILD_TYPE=Debug and using the default
+#             debug flags. Note that there is yet another build type for release plus symbols.
+#
+#             So far I have removed -Bstatic because it is causes problems and cmake seems to do enough
+#             magically.
+#
+#################################################################################################
+
+
+###Compile flags
+set(CMAKE_Fortran_FLAGS_RELEASE "-g " CACHE STRING "Fortran flags" FORCE)
+# set(CMAKE_Fortran_FLAGS_RELEASE "-O2 -mcmodel=medium -assume byterecl" CACHE STRING "Fortran flags" FORCE)
+##For final linking: this is only needed in exordinary cases
+#set(CMAKE_EXE_LINKER_FLAGS "" CACHE STRING "linker" FORCE)
+
+###MPI_VERSION cannot be set here; use -DMPIVERSION=XX in cmake cmd instead
+#set(MPI_VERSION CACHE STRING  "1")
+
+###FABM usage
+set( USE_FABM ON   CACHE BOOLEAN "FABM BGC model interface")
+#If FABM is on, need to set FABM_BASE
+set(FABM_BASE /beegfs/home/Wyrwa/FABM/fabm4schism)
+
+################################################################################################# notes
+# Wyrwa@phil-hpc.hpc:~/SCHISM/github_schism17okt25/entwicklung> rsync -va . /beegfs/home/Wyrwa/SCHISM/github_schism17okt25
+# cmake -C ../cmake/SCHISM.local.build -C ../cmake/SCHISM.local.phil.bfg ../src/
+# cmake --build .
+#
+# previously:
+# Wyrwa@phil-hpc.hpc:~/SCHISM/github_schism17okt25/entwicklung> rsync -va ./src /beegfs/home/Wyrwa/SCHISM/github_schism17okt25/src
+# cmake -C ../cmake/SCHISM.local.build -C ../cmake/SCHISM.local.phil.bfg -DUSE_FABM=ON -DFABM_BASE=/beegfs/home/Wyrwa/FABM/fabm4schism -DFABM_EXTRA_INSTITUTES=uzweijens -DFABM_UZWEIJENS_BASE=../src/QSim/ ../src/
+# 

--- a/src/Hydro/schism_init.F90
+++ b/src/Hydro/schism_init.F90
@@ -445,13 +445,15 @@
       !just add the output statements in _step and flags in param.nml (same
       !order). Flags for modules other than hydro are only used inside USE_*
       if(iorder==0) then
-        allocate(iof_hydro(40),iof_wwm(40),iof_gen(max(1,ntracer_gen)),iof_age(max(1,ntracer_age)),level_age(ntracer_age/2), &
-     &iof_sed(3*sed_class+20),iof_eco(max(1,eco_class)),iof_icm_core(17),iof_icm_silica(2),iof_icm_zb(2),iof_icm_ph(4), &
-     &iof_icm_srm(4),iof_cos(20),iof_fib(5),iof_sed2d(14),iof_ice(10),iof_mice(10),iof_ana(20),iof_marsh(2),iof_dvd(max(1,ntrs(12))), &
-      !dim of srqst7 increased to account for 2D elem/side etc
-     &srqst7(nscribes+10),veg_vert_z(nbins_veg_vert+1),veg_vert_scale_cd(nbins_veg_vert+1), &
-     &veg_vert_scale_N(nbins_veg_vert+1),veg_vert_scale_D(nbins_veg_vert+1), &
-     &veg_di0(nmarsh_types),veg_h0(nmarsh_types),veg_nv0(nmarsh_types),veg_cd0(nmarsh_types),drown_marsh(nmarsh_types),stat=istat)
+        allocate(iof_hydro(40),iof_wwm(40),iof_gen(max(1,ntracer_gen)),iof_age(max(1,ntracer_age)),    &
+        &level_age(ntracer_age/2), iof_sed(3*sed_class+20),iof_eco(max(1,eco_class)),iof_icm_core(17), &
+        &iof_icm_silica(2),iof_icm_zb(2),iof_icm_ph(4), iof_icm_srm(4),iof_cos(20),iof_fib(5),         &
+        &iof_sed2d(14),iof_ice(10),iof_mice(10),iof_ana(20),iof_marsh(2),iof_dvd(max(1,ntrs(12))),     &
+        &srqst7(nscribes+10),veg_vert_z(nbins_veg_vert+1),veg_vert_scale_cd(nbins_veg_vert+1),         &
+        &veg_vert_scale_N(nbins_veg_vert+1),veg_vert_scale_D(nbins_veg_vert+1), veg_di0(nmarsh_types), &
+        &veg_h0(nmarsh_types),veg_nv0(nmarsh_types),veg_cd0(nmarsh_types),drown_marsh(nmarsh_types),   &
+        &stat=istat)
+        !dim of srqst7 increased to account for 2D elem/side etc
         if(istat/=0) call parallel_abort('INIT: iof failure')
         srqst7(:)=MPI_REQUEST_NULL
         !Global output on/off flags

--- a/src/Hydro/schism_step.F90
+++ b/src/Hydro/schism_step.F90
@@ -2141,7 +2141,8 @@
         irec2(2)=(it+1)*nstride_schout+irec0_schout-(istack(2)-1)*nrec_schout !->time step n+1 (new)
         if(istack(2)>istack(1)) then !if istack(2) not exisit (last record), use previous stack
           write(it_char,'(i72)')istack(2)
-          inquire(file=in_dir(1:len_in_dir)//'hydro_out/'//trim(adjustl(snames_schout(1)))//'_'//trim(adjustl(it_char))//'.nc',exist=ltmp)
+          inquire(file=  & 
+&in_dir(1:len_in_dir)//'hydro_out/'//trim(adjustl(snames_schout(1)))//'_'//trim(adjustl(it_char))//'.nc',exist=ltmp)
           if(.not.ltmp) then !not exist; use same stack and reset record #
             istack(2)=istack(1); irec2(2)=irec2(1)
           endif

--- a/src/Utility/Combining_Scripts/combine_output11.f90
+++ b/src/Utility/Combining_Scripts/combine_output11.f90
@@ -12,7 +12,8 @@
 ! Output: combined nc file
 !
 
-!  ifort -cpp -O2 -assume byterecl -o combine_output11.exe ../UtilLib/argparse.f90 ../UtilLib/schism_geometry.f90 combine_output11.f90 -I$NETCDF/include -I$NETCDF_FORTRAN/include -L$NETCDF_FORTRAN/lib -L$NETCDF/lib -lnetcdf -lnetcdff
+!  ifort -cpp -O2 -assume byterecl -o combine_output11.exe ../UtilLib/argparse.f90 ../UtilLib/schism_geometry.f90 & 
+!  & combine_output11.f90 -I$NETCDF/include -I$NETCDF_FORTRAN/include -L$NETCDF_FORTRAN/lib -L$NETCDF/lib -lnetcdf -lnetcdff
 
 !  History: 
 !          2018-1      Richard Hofmeister changed the combine method (all vars read in at a
@@ -989,7 +990,8 @@ cfile = ""
 !files=""
 
 cmd_name = "combine_output11"
-call cla_init(cmd_name,"Combine time blocked per-processor binary outputs (e.g. 'schout_000000_1.nc') into time blocked global outputs ('schout_1.nc')")
+call cla_init(cmd_name,"Combine time blocked per-processor binary outputs (e.g. 'schout_000000_1.nc') &
+&into time blocked global outputs ('schout_1.nc')")
 
 !call cla_register('-i','--in', 'input file (e.g. combine_input.in) containing options (overridden by command line specs)', cla_char,'')
 call cla_register('-b','--begin', 'start day', cla_int,'-1')

--- a/src/Utility/Post-Processing-Fortran/read_output10_xyz.f90
+++ b/src/Utility/Post-Processing-Fortran/read_output10_xyz.f90
@@ -63,7 +63,8 @@
       read(*,*)ibp
       if(ibp/=1.and.ibp/=2) stop 'Unknown format'
 
-      print*, 'Input ics (1-linear interp; 2-nearest neighbor interp. 2 for node-based variables only! 2 is suggested for sub-meter resolution!):'
+      print*, 'Input ics (1-linear interp; 2-nearest neighbor interp. 2 for node-based variables only! &
+      &       2 is suggested for sub-meter resolution!):'
       read(*,*)ics
 
       print*, 'Input variable name to read from nc (e.g. elevation):'

--- a/src/Utility/Post-Processing-Fortran/read_output9_xyz.f90
+++ b/src/Utility/Post-Processing-Fortran/read_output9_xyz.f90
@@ -79,7 +79,8 @@
       read(*,*)ibp
       if(ibp/=1.and.ibp/=2) stop 'Unknown format'
 
-      print*, 'Input ics (1-linear interp; 2-nearest neighbor interp. 2 for node-based variables only! 2 is suggested for sub-meter resolution!):'
+      print*, 'Input ics (1-linear interp; 2-nearest neighbor interp. 2 for node-based variables only!  &
+      &       2 is suggested for sub-meter resolution!):'
       read(*,*)ics
 
       print*, 'Input variable name to read from nc (e.g. elev):'


### PR DESCRIPTION
schism_step.F90 was changed between line 1408 and 1459
in order to allow for boundary time series flux.th and elev.th
that have 
1) uneven timestepping and
2) timesteps shorter than the simulation time step