### PR TITLE
Fix veg_lai and veg_cw type declaration: integer -> real

### DIFF
--- a/src/Core/schism_glbl.F90
+++ b/src/Core/schism_glbl.F90
@@ -94,7 +94,7 @@ module schism_glbl
                   &nstep_ice,niter_shap,iunder_deep,flag_fib,ielm_transport,max_subcyc, &
                   &itransport_only,iloadtide,nc_out,nu_sum_mult,iprecip_off_bnd, &
                   &iof_ugrid,model_type_pahm,iof_icm_sav,iof_icm_marsh,iof_icm_sfm,iof_icm_ba,&
-                  &iof_icm_clam,nbins_veg_vert,veg_lai,veg_cw,niter_hdif,nmarsh_types,istemp
+                  &iof_icm_clam,nbins_veg_vert,niter_hdif,nmarsh_types,istemp
   integer,save :: ntrs(natrm),nnu_pts(natrm),mnu_pts,lev_tr_source(natrm)
   integer,save,dimension(:),allocatable :: iof_hydro,iof_wwm,iof_gen,iof_age,iof_sed,iof_eco, &
      &iof_icm,iof_icm_core,iof_icm_silica,iof_icm_zb,iof_icm_ph,iof_icm_srm,iof_cos,iof_fib, &
@@ -111,7 +111,7 @@ module schism_glbl
                       &hmin_airsea_ex,hmin_salt_ex,shapiro0,loadtide_coef,h_massconsv,rinflation_icm, &
                       &ref_ts_h1,ref_ts_h2,ref_ts_restore_depth,ref_ts_tscale, &
                       &ref_ts_dt,watertype_rr,watertype_d1,watertype_d2,ri_st, &
-                      &create_marsh_min,create_marsh_max,age_marsh_min,relax_2_airt
+                      &create_marsh_min,create_marsh_max,age_marsh_min,relax_2_airt,veg_lai,veg_cw
   real(rkind),save,allocatable :: veg_vert_z(:),veg_vert_scale_cd(:),veg_vert_scale_N(:),veg_vert_scale_D(:), &
         &veg_di0(:),veg_h0(:),veg_nv0(:),veg_cd0(:),drown_marsh(:)
 


### PR DESCRIPTION
These variables are incorrectly declared as integers but are used as real values (e.g., veg_cw=1.5). When users specify float values in param.nml (such those in the [example_inputs/param.nml](https://github.com/schism-dev/schism/blob/master/sample_inputs/param.nml#L709-L710)), Fortran fails to parse the namelist:
```
  Error termination. Backtrace:
  At line 537 of file .../src/Hydro/schism_init.F90 (unit = 15, file = './/param.nml')
  Fortran runtime error: Cannot match namelist object name .
```

Moving veg_lai and veg_cw from integer to real(rkind) declaration block fixes the issue by making the declarations consistent.