### PR TITLE
Fix CMake race condition in parallel builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,9 +4,8 @@ cmake_minimum_required (VERSION 3.12)
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
-# This policy has to do with variables called <module>_ROOT
-# and possible collisions with module-finding.
-cmake_policy(SET CMP0074 OLD)
+# CMP0074: find_package() uses <PackageName>_ROOT variables
+cmake_policy(SET CMP0074 NEW)
 
 
 enable_testing()

--- a/src/Utility/ArcGIS/CMakeLists.txt
+++ b/src/Utility/ArcGIS/CMakeLists.txt
@@ -1,10 +1,11 @@
-
-
 add_executable( binary_2_ncstruc binary_2_ncstruc.f90)
 
 #add_executable( read_output7b_group_zfs2 read_output7b_group_zfs2.f90)
 
-
-target_link_libraries (binary_2_ncstruc ${NetCDFLIBS} ${HDF5_LIBRARIES} schism_geometry)
-add_dependencies(utility binary_2_ncstruc read_output7b_group_zfs2)
+# Link to utillib which contains stripesearch_unstr.f90 (called by binary_2_ncstruc)
+target_link_libraries(binary_2_ncstruc ${NetCDFLIBS} ${HDF5_LIBRARIES} utillib)
+target_include_directories(binary_2_ncstruc PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../UtilLib)
+# Add dependency on utillib to ensure it's built before compilation
+add_dependencies(binary_2_ncstruc utillib)
+add_dependencies(utility binary_2_ncstruc)
 

--- a/src/Utility/Grid_Scripts/CMakeLists.txt
+++ b/src/Utility/Grid_Scripts/CMakeLists.txt
@@ -15,3 +15,8 @@ add_executable(mergegrid5 mergegrid5.f90)
 target_link_libraries(mergegrid5 utillib)
 target_include_directories(mergegrid5 PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../UtilLib)
 add_dependencies(mergegrid5 utillib)
+
+# Add dependency on utillib for executables that define their own modules
+# to ensure utillib modules are built first and avoid race conditions
+# when multiple targets write .mod files to the shared include directory
+add_dependencies(interpolate_unstructured utillib)

--- a/src/Utility/Particle_Tracking/CMakeLists.txt
+++ b/src/Utility/Particle_Tracking/CMakeLists.txt
@@ -4,5 +4,7 @@ add_executable(ptrack3 ptrack3.f90)
 add_dependencies(utility ptrack3) ## ptrack4)
 target_link_libraries(ptrack3 utillib ${NetCDFLIBS} ${HDF5_LIBRARIES})
 target_include_directories(ptrack3 PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../UtilLib)
+# Add dependency on utillib to ensure Fortran .mod files exist before compilation
+add_dependencies(ptrack3 utillib)
 #target_link_libraries(ptrack4 utillib ${NetCDFLIBS} ${HDF5_LIBRARIES})
 #target_include_directories(ptrack4 PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../UtilLib)

--- a/src/Utility/Pre-Processing/CMakeLists.txt
+++ b/src/Utility/Pre-Processing/CMakeLists.txt
@@ -58,3 +58,15 @@ target_link_libraries(gen_nudge_from_hycom utillib ${NetCDFLIBS} ${HDF5_LIBRARIE
 target_include_directories(gen_vqs_1 PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../UtilLib)
 target_include_directories(gen_vqs_2masters PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../UtilLib)
 target_include_directories(gen_nudge_from_hycom PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../UtilLib)
+
+# Add dependencies on utillib for targets that use utillib modules
+# to ensure Fortran .mod files exist before compilation
+add_dependencies(convert_3Dth_nc utillib)
+add_dependencies(convert_nudge_nc utillib)
+add_dependencies(gen_vqs_1 utillib)
+add_dependencies(gen_vqs_2masters utillib)
+add_dependencies(gen_nudge_from_hycom utillib)
+
+# Add dependency for gen_source which defines its own 'module global'
+# to avoid race conditions with other modules in the shared include directory
+add_dependencies(gen_source utillib)


### PR DESCRIPTION
When compiling with make -jN, a transient race condition can occur where multiple utilities attempt to write .mod files to the shared include directory simultaneously:                    
 ```make                                                                                                                                                                                         
f951: Fatal Error: Cannot rename module file '../../include/global.mod0' to '../../include/global.mod': No such file or directory
```
                                                                                                                                                                   
This happens because utilities like gen_source and interpolate_unstructured define their own module global, and without explicit build ordering, they can compile in parallel and conflict.
                                                                                                                                 
Fix: Add add_dependencies() to utility CMakeLists.txt files to ensure utillib is built first, serializing module file generation.                                                          
                                                                                                                          
Changes:                                                                                                                                                                                   
- Grid_Scripts: add dependency for interpolate_unstructured                                                                                                                                
- Pre-Processing: add dependencies for targets using utillib modules                                                                                                                       
- Particle_Tracking: add dependency for ptrack3                                                                                                                                            
- ArcGIS: fix incorrect schism_geometry link (should be utillib)                                                                                                                           
