### PR TITLE
Fixes for SAL

### DIFF
--- a/src/Hydro/misc_subs.F90
+++ b/src/Hydro/misc_subs.F90
@@ -6812,7 +6812,7 @@
           do i=0,359 
             do j=-90,90
               nd=isal_int(j+90,i) !global node # or -1
-              if(nd>0) avhs1(j,i)=eta_gb(nd)
+              if(nd>0) avhs1(j+90,i)=eta_gb(nd)
 
               !Debug
 !              nt=nt+1

--- a/src/Hydro/schism_init.F90
+++ b/src/Hydro/schism_init.F90
@@ -2368,6 +2368,9 @@
         do i=1,np_global
           read(32,*)j,buf3(i),buf4(i)
         enddo !i
+        do i=1,np_global
+          buf3(i)=modulo(buf3(i),360.d0)   ! force lon into [0,360); ±360 shift below still handles the seam
+        enddo
         do i=1,ne_global
           read(32,*)j,nwild2(i),nwild3(1:nwild2(i),i)
         enddo !i

--- a/src/Hydro/schism_step.F90
+++ b/src/Hydro/schism_step.F90
@@ -471,7 +471,7 @@ real (rkind) :: aux                               ! ustar
           etp(i)=etp(i)+0.69d0*ramp*tamp(j)*tnf(j)*fun_lat(jspc(j),i)*cos(arg)
 
           if(iloadtide==1) then !loading tide from FES etc
-            etp(i)=etp(i)+rloadtide(1,j,i)*cos(tfreq(j)*time-rloadtide(2,j,i))
+            etp(i)=etp(i)+rloadtide(1,j,i)*cos(tfreq(j)*time+tear(j)-rloadtide(2,j,i))
           endif !iloadtide
         enddo !j
 


### PR DESCRIPTION
Hi Joseph, 

Here are the fixes for:
 * the full SAL approach (iloadtide=4)
 * the SAL map forcing (iloadtide=1)

The main caveat in the 1st fix is that the `modulo` does not apply for local / UTM projections. 
SAL should be mainly used in large regional or global models, but still I wanted to flag this. 

I will provide more info later on: 
 * the error improvement of iloadtide=4
 * the proper way to generate SAL maps from FES2014/FES2022